### PR TITLE
Allow customisation of copy path

### DIFF
--- a/dev-server/src/index.js
+++ b/dev-server/src/index.js
@@ -45,10 +45,14 @@ ReactDom.render(
             // enableCopyNodePath={copy=>{
             //    console.log('copied', copy)
             // }}
-            
+            enableCopyNodePath={true}
             // enableClipboard={copy => {
             //     console.log('you copied to clipboard!', copy);
             // }}
+            onCustomPath={({name, namespace, src}) =>{
+               return namespace.join('/');
+            }}
+            // onCustomPath={()=>"test"}
             shouldCollapse={({ src, namespace, type }) => {
                 if (type === 'array' && src.indexOf('test') > -1) {
                     return true;

--- a/index.d.ts
+++ b/index.d.ts
@@ -78,10 +78,24 @@ export interface ReactJsonViewProps {
   /**
    * When prop is not false, the user can copy the json node path to clipboard by clicking on the clipboard icon.
    * Copy callbacks are supported.
+   * By default, the path returned is in the format: `root['child_node']['grand_child_node'].
+   * You can customise the calculation for the path by using the `onCustomPath` prop. 
    *
    * Default: true
    */
-   enableCopyNodePath?: boolean | ((copy: OnCopyNodePathProps) => void);
+  enableCopyNodePath?: boolean | ((copy: OnCopyNodePathProps) => void);
+   /**
+    * When `enableCopyNodePath` is `true`, the user can use this `prop` to return a custom node path.
+    * Pass a function that returns your custom node path.
+    * Example:
+    * onCustomPath={({src,name,namespace}) => {
+    *    return namespace.join('/');
+    * }}
+    * The returned custom path value will then be copied to clipboard passed on to callback(if any) set by enableCopyNodePath.
+    * 
+    * Default: null
+    */
+  onCustomPath?: ((copy: OnCopyProps) => string);
   /**
    * When set to true, objects and arrays are labeled with size.
    *

--- a/src/js/components/VariableEditor.js
+++ b/src/js/components/VariableEditor.js
@@ -57,7 +57,8 @@ class VariableEditor extends React.PureComponent {
             displayArrayKey,
             quotesOnKeys,
             enableCopyNodePath,
-            copyPathLabel
+            copyPathLabel,
+            onCustomPath
         } = this.props;
         const { editMode } = this.state;
         return (
@@ -138,6 +139,7 @@ class VariableEditor extends React.PureComponent {
                         src={variable.value}
                         clickCallback={enableCopyNodePath}
                         copyPathLabel={copyPathLabel}
+                        onCustomPath={onCustomPath}
                         {...{ theme, namespace: [...namespace, variable.name] }}
                     />
                 ) : null}

--- a/src/js/components/VariableMeta.js
+++ b/src/js/components/VariableMeta.js
@@ -117,7 +117,8 @@ export default class extends React.PureComponent {
             namespace,
             rowHovered,
             enableCopyNodePath,
-            copyPathLabel
+            copyPathLabel,
+            onCustomPath
         } = this.props;
         return (
             <div
@@ -135,6 +136,7 @@ export default class extends React.PureComponent {
                         rowHovered={rowHovered}
                         clickCallback={enableCopyNodePath}
                         copyPathLabel={copyPathLabel}
+                        onCustomPath={onCustomPath}
                         {...{ src, theme, namespace }}
                     />
                 ) : null}

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -62,7 +62,8 @@ class ReactJsonView extends React.PureComponent {
         displayArrayKey: true,
         enableCopyNodePath: true,
         path: '',
-        copyPathLabel:  'Copy path to clipboard'
+        copyPathLabel:  'Copy path to clipboard',
+        onCustomPath: null
     };
 
     // will trigger whenever setState() is called, or parent passes in new props.


### PR DESCRIPTION
This PR fixes #1139 and allows one to build a custom `node path` via the `onCustomPath` `prop`. 
Example:
```
<ReactJson 
onCustomPath={({src, name, namespace}) => {
  return namespace.join('/');
}
/>
```
The example above will return a JSON `node path` that looks like `root/child_node/grand_child_node`, and then the custom path value will  be copied to clipboard and passed on to callback(if any) set by `enableCopyNodePath`.